### PR TITLE
Mark as compatible with Factorio 0.16

### DIFF
--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 	"name":"BottleneckLogistics",
 	"author":"Nexela",
 	"version":"1.2.0",
-	"factorio_version": "0.15",
+	"factorio_version": "0.16",
 	"title":"Bottleneck Logistics",
 	"homepage":"https://forums.factorio.com/viewtopic.php?f=144&t=28817",
 	"description":"A tool for locating logistic chests not inside a network.",


### PR DESCRIPTION
I've used this mod with Factorio 0.16 for months, and never encountered any issues whatsoever related to it. Seems to work just fine, so why not mark it as compatible?

As a note, though: I have been using version 1.2.1 of the mod. There seems to be a fair number of changes between the version published here (some stage of 1.2.0) and the release of 1.2.1 on the mod portal. I'm not sure if that affects the compatibility, but it would be very nice to have the code here on GitHub updated in any case. Maybe even an official release of the mod for 0.16, now that's it's been stable for a while.